### PR TITLE
changing assay to not be hard coded

### DIFF
--- a/R/fastCNV_10XHD.R
+++ b/R/fastCNV_10XHD.R
@@ -133,7 +133,7 @@ fastCNV_10XHD <- function(seuratObjHD,
   seuratObjHD[["genomicScores"]] = Seurat::GetAssay(newHDobj, assay = "genomicScores")
   seuratObjHD$cnv_fraction = NA
   seuratObjHD$cnv_fraction[rownames(newHDobj@meta.data)] = newHDobj$cnv_fraction
-  Seurat::DefaultAssay(seuratObjHD) = "Spatial.016um"
+  Seurat::DefaultAssay(seuratObjHD) = assay
   seuratObjHD@project.name = sampleName
   rm(newHDobj) ; invisible(gc())
 


### PR DESCRIPTION
DefaultAssay is hard coded in the fastCNV_10XHD function which results in an error when trying to run the function using a different assay. Changing this to the assay option of the function fixes this. 