### PR TITLE
Update clone color handling in plotCNVTree function and documentation

### DIFF
--- a/R/CNVcluster.R
+++ b/R/CNVcluster.R
@@ -80,7 +80,7 @@ CNVCluster <- function(seuratObj,
     }
 
     if (kDetection == "automatic") {
-      k_values <- 1:15
+      k_values <- 1:8
       wss <- sapply(k_values, function(k) {
         clusters <- cutree(hc, k = k)
         sum(sapply(unique(clusters), function(cl) {

--- a/R/CNVcluster.R
+++ b/R/CNVcluster.R
@@ -80,7 +80,8 @@ CNVCluster <- function(seuratObj,
     }
 
     if (kDetection == "automatic") {
-      k_values <- 1:8
+      k_max <- min(15, length(hc$order) - 1)
+      k_values <- 1:k_max
       wss <- sapply(k_values, function(k) {
         clusters <- cutree(hc, k = k)
         sum(sapply(unique(clusters), function(cl) {

--- a/R/CNVcluster.R
+++ b/R/CNVcluster.R
@@ -79,15 +79,16 @@ CNVCluster <- function(seuratObj,
       return(x[elbow_point + 1])
     }
 
-    k_values <- 1:15
-    wss <- sapply(k_values, function(k) {
-      clusters <- cutree(hc, k = k)
-      sum(sapply(unique(clusters), function(cl) {
-        sum(dist_matrix_full[which(clusters == cl), which(clusters == cl)]^2) / (2 * sum(clusters == cl))
-      }))
-    })
-
-    if(kDetection == "automatic") {k <- find_elbow(k_values, wss)}
+    if (kDetection == "automatic") {
+      k_values <- 1:15
+      wss <- sapply(k_values, function(k) {
+        clusters <- cutree(hc, k = k)
+        sum(sapply(unique(clusters), function(cl) {
+          sum(dist_matrix_full[which(clusters == cl), which(clusters == cl)]^2) / (2 * sum(clusters == cl))
+        }))
+      })
+      k <- find_elbow(k_values, wss)
+    }
 
     clusters <- cutree(hc, k = k, h = h)
 

--- a/R/plotCNVResults.R
+++ b/R/plotCNVResults.R
@@ -124,7 +124,11 @@ plotCNVResults <- function(seuratObj,
   if (!is.null(referenceVar)) {
     annotation_df <- as.data.frame(seuratObj@meta.data[[referenceVar]])
     colnames(annotation_df) <- "Annotations"
-    annot_colors <- setNames(referencePalette[1:length(unique(annotation_df$Annotations))], unique(annotation_df$Annotations))
+    if (is.null(names(referencePalette))) {
+      annot_colors <- setNames(referencePalette[1:length(unique(annotation_df$Annotations))], unique(annotation_df$Annotations))
+    } else {
+      annot_colors <- referencePalette
+    }
     if (!is.null(splitPlotOnVar)) {
       split_df <- as.data.frame(Seurat::FetchData(seuratObj, vars = splitPlotOnVar))
       colnames(split_df) <- "Split"

--- a/R/plotCNVResultsHD.R
+++ b/R/plotCNVResultsHD.R
@@ -112,7 +112,11 @@ plotCNVResultsHD <- function(seuratObjHD,
   if (!is.null(referenceVar)) {
     annotation_df <- suppressWarnings(as.data.frame(Seurat::FetchData(seuratObjHD, vars = referenceVar)))
     colnames(annotation_df) <- "Annotations"
-    annot_colors <- setNames(referencePalette[1:length(unique(annotation_df$Annotations))], unique(annotation_df$Annotations))
+    if (is.null(names(referencePalette))) {
+      annot_colors <- setNames(referencePalette[1:length(unique(annotation_df$Annotations))], unique(annotation_df$Annotations))
+    } else {
+      annot_colors <- referencePalette
+    }
     if (!is.null(splitPlotOnVar)) {
       split_df <- suppressWarnings(as.data.frame(Seurat::FetchData(seuratObjHD, vars = splitPlotOnVar)))
       colnames(split_df) <- "Split"

--- a/R/plotCNVtree.R
+++ b/R/plotCNVtree.R
@@ -42,9 +42,9 @@ plotCNVTree <- function(tree_data, clone_cols = NULL) {
                                          order(as.numeric(sub(".* (\\d+)$", "\\1", tree_data$label[tree_data$isTip])))
                                        ])),size = 4)
 
-    if(length(clone_cols) == sum(tree_data$isTip)) {
+    if(length(clone_cols) >= sum(tree_data$isTip)) {
       tree_plot <- tree_plot +
-        scale_color_manual(values = clone_cols)
+        scale_color_manual(values = clone_cols[1:sum(tree_data$isTip)])
     }
 
   }

--- a/man/CNVtree.Rd
+++ b/man/CNVtree.Rd
@@ -34,7 +34,8 @@ of CNV calls (0=none, 1=gain, -1=loss).}
 \item{clone_cols}{a color palette to color the clones. If NULL, points are
 not colored. If TRUE, clones are colored using default color palette. If a
 palette is given, clones are colored following the palette, with
-values passed to \code{scale_color_manual}.}
+values passed to \code{scale_color_manual}. Custom palettes should contain 
+at least as many colors as the number of clones in the tree.}
 }
 \description{
 Build, annotate and plot a Phylogenetic Tree from a seurat Object containing the CNV results from \code{fastCNV()}

--- a/man/plotCNVtree.Rd
+++ b/man/plotCNVtree.Rd
@@ -13,7 +13,8 @@ typically produced by \code{annotateCNVtree}.}
 \item{clone_cols}{a color palette to color the clones. If NULL, points are
 not colored. If TRUE, clones are colored using default color palette. If a
 palette is given, clones are colored following the palette, with
-values passed to \code{scale_color_manual}.}
+values passed to \code{scale_color_manual}. Custom palettes should contain 
+at least as many colors as the number of clones in the tree.}
 }
 \value{
 A \code{ggplot} object representing the annotated phylogenetic tree.


### PR DESCRIPTION
## Summary
This PR refactors the CNV clustering logic to prevent execution errors on small datasets and enhances color palette handling across visualization functions to support consistent multi-dataset analysis.

## Changes
### 1. Clustering logic improvements

- **Conditional Evaluation:** Optimized the workflow to perform k value evaluation only when `kDetection == "automatic"`. This prevents unnecessary computation and potential crashes when a manual k is specified.

- **Dynamic `k` Range:** Fixed a "hardcoded range" bug where evaluation attempted to test `k_values <- 1:15` regardless of the number of available nodes.

``` R
[2026-04-15 11:10:59] Aggregating counts matrix...
[2026-04-15 11:11:10] Done !
[2026-04-15 11:11:10] Running CNV analysis...
Using genes data from ensembl version 113.
[2026-04-15 11:11:22] Done !
[2026-04-15 11:11:22] Computing CNV per chromosome arm...
[2026-04-15 11:11:23] Done !
[2026-04-15 11:11:23] Clustering CNVs...
Error in cutree(hc, k = k) : elements of 'k' must be between 1 and 14
```
The maximum  `k` is now dynamically set to `min(15, length(hc$order) - 1)` to avoid such errors.

### 2. Visualization & Color Palette Handling
 - **Named Palette Support** (`plotCNVResults` / `plotCNVResultsHD`):
    - **Previous:** `referencePalette` names were ignored, and colors were reassigned based on the order of appearance in the annotation data.frame. 
    - **New Behavior:** Functions now respect named color palettes. This allows users to enforce a unified color scheme across different patients or datasets.

- **Robust Clone Coloring** (plotCNVTree):
   - **Previous:**  the function discarded the entire palette if the length didn't match the clone count exactly.
   - **New Behavior:** The function now validates that the palette has at least enough colors and subsets it as needed. This allows the use of a large, master palette across multiple objects.

- Documentation: Updated .Rd files for `CNVtree` and `plotCNVtree` to clarify the requirements for custom clone_cols.
